### PR TITLE
Update documentation

### DIFF
--- a/OpenEphys.ProbeInterface/OpenEphys.ProbeInterface.csproj
+++ b/OpenEphys.ProbeInterface/OpenEphys.ProbeInterface.csproj
@@ -1,34 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
+	
   <PropertyGroup>
-	<Title>OpenEphys.ProbeInterface</Title>
-	<Authors>Open Ephys</Authors>
-	<Copyright>Copyright © Open Ephys and Contributors 2024</Copyright>
-	<TargetFramework>net472</TargetFramework>
-	<Description>API based on Probe Interface specifications for parsing channel configurations</Description>
-	<PackageTags>Bonsai Rx Open Ephys Onix</PackageTags>
-	<VersionPrefix>0.1.0</VersionPrefix>
-	<SymbolPackageFormat>snupkg</SymbolPackageFormat>
-  <UseArtifactsOutput>true</UseArtifactsOutput>
-  <GenerateDocumentationFile>true</GenerateDocumentationFile>
-	<PackageProjectUrl></PackageProjectUrl>
-	<IncludeSymbols>true</IncludeSymbols>
-	<RepositoryUrl>https://github.com/open-ephys/OpenEphys.ProbeInterface</RepositoryUrl>
-	<RepositoryType>git</RepositoryType>
-	<PackageLicenseFile>LICENSE</PackageLicenseFile>
-	<PackageIcon>icon.png</PackageIcon>
-	<VersionSuffix></VersionSuffix>
-	<LangVersion>10.0</LangVersion>
-	<Nullable>enable</Nullable>
-	<Platforms>AnyCPU</Platforms>
+    <Title>OpenEphys.ProbeInterface</Title>
+    <Authors>Open Ephys</Authors>
+    <Copyright>Copyright © Open Ephys and Contributors 2024</Copyright>
+    <TargetFramework>net472</TargetFramework>
+    <Description>API based on Probe Interface specifications for parsing channel configurations</Description>
+    <PackageTags>Bonsai Rx Open Ephys Onix</PackageTags>
+    <VersionPrefix>0.1.0</VersionPrefix>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <PackageProjectUrl></PackageProjectUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <RepositoryUrl>https://github.com/open-ephys/OpenEphys.ProbeInterface</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageIcon>icon.png</PackageIcon>
+    <VersionSuffix></VersionSuffix>
+    <LangVersion>10.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <Platforms>AnyCPU</Platforms>
   </PropertyGroup>
-
-	<ItemGroup>
-		<Content Include="..\..\LICENSE" PackagePath="/" />
-		<Content Include="..\..\icon.png" PackagePath="/" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-	</ItemGroup>
+  
+  <ItemGroup>
+    <Content Include="..\LICENSE" PackagePath="/" />
+    <Content Include="..\icon.png" PackagePath="/" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # OpenEphys.ProbeInterface
-C# API based on [Probe Interface](https://probeinterface.readthedocs.io/en/main/index.html) specifications for parsing channel configurations
+C# .NET API based on [Probe Interface](https://probeinterface.readthedocs.io/en/main/index.html) specifications for parsing channel configurations.


### PR DESCRIPTION
Documentation was previously implemented with sub-standard formatting. This PR aims to increase the useability of all documentation by correctly utilizing XML tags, specifically making `<summary>` tags short and succinct, with all additional information pushed to the `<remarks>` tags.