### PR TITLE
Add JsonProperty attributes to contact shape parameters

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.1.1</VersionPrefix>
+    <VersionPrefix>0.2.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.ProbeInterface.NET/ContactShapeParam.cs
+++ b/OpenEphys.ProbeInterface.NET/ContactShapeParam.cs
@@ -16,6 +16,7 @@ namespace OpenEphys.ProbeInterface.NET
         /// <remarks>
         /// This is only used to draw <see cref="ContactShape.Circle"/> contacts. Field can be null.
         /// </remarks>
+        [JsonProperty("radius")]
         public float? Radius { get; protected set; }
 
         /// <summary>
@@ -25,6 +26,7 @@ namespace OpenEphys.ProbeInterface.NET
         /// This is used to draw <see cref="ContactShape.Square"/> or <see cref="ContactShape.Rect"/> contacts.
         /// Field can be null.
         /// </remarks>
+        [JsonProperty("width")]
         public float? Width { get; protected set; }
 
         /// <summary>
@@ -33,6 +35,7 @@ namespace OpenEphys.ProbeInterface.NET
         /// <remarks>
         /// This is only used to draw <see cref="ContactShape.Rect"/> contacts. Field can be null.
         /// </remarks>
+        [JsonProperty("height")]
         public float? Height { get; protected set; }
 
         /// <summary>


### PR DESCRIPTION
The initial implementation left the names of the properties as-is when serializing; while this did not cause issues for `radius` or `height`, surprisingly, it did throw a keyError for `width`. Nevertheless, the JSON schema shows all properties as being lowercase, so that is what they have been modified to be.