### PR TITLE
Ensure contact annotations use the correct Json Property name

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <UseArtifactsOutput>true</UseArtifactsOutput>
     <PackageIcon>icon.png</PackageIcon>
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.3.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <LangVersion>10.0</LangVersion>
     <Features>strict</Features>

--- a/OpenEphys.ProbeInterface.NET/ContactAnnotations.cs
+++ b/OpenEphys.ProbeInterface.NET/ContactAnnotations.cs
@@ -10,16 +10,17 @@ namespace OpenEphys.ProbeInterface.NET
         /// <summary>
         /// Gets the array of strings holding annotations for each contact. Not all indices must have annotations.
         /// </summary>
+        [JsonProperty("annotations")]
         public string[] Annotations { get; protected set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ContactAnnotations"/> class.
         /// </summary>
-        /// <param name="contactAnnotations">Array of strings containing annotations for each contact. Size of the array should match the number of contacts, but they can be empty strings.</param>
+        /// <param name="annotations">Array of strings containing annotations for each contact. Size of the array should match the number of contacts, but they can be empty strings.</param>
         [JsonConstructor]
-        public ContactAnnotations(string[] contactAnnotations)
+        public ContactAnnotations(string[] annotations)
         {
-            Annotations = contactAnnotations;
+            Annotations = annotations;
         }
     }
 }


### PR DESCRIPTION
This is a breaking change to the API, but since we are still in a 0.y.z release it is only being tagged as a minor revision.

The JSON property name for `ContactAnnotations`, specifically the sub property `Annotations`, was not being named correctly via the `JsonProperty` attribute and as such was not being deserialized correctly from a configuration file.

This PR fixes this name change.